### PR TITLE
Update dependencies/uWS to v20.52.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,23 @@
 {
   "name": "ultimate-ws",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ultimate-ws",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "tseep": "^1.3.1",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.51.0",
-        "ws": "^8.18.0"
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.52.0",
+        "ws": "^8.18.2"
       },
       "devDependencies": {
         "exit-hook": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/exit-hook": {
@@ -30,49 +33,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/tseep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
       "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==",
       "license": "MIT"
     },
-    "node_modules/utf-8-validate": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.4.tgz",
-      "integrity": "sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/uWebSockets.js": {
-      "version": "20.51.0",
-      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#6609a88ffa9a16ac5158046761356ce03250a0df",
+      "version": "20.52.0",
+      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#cfc9a40d8132a34881813cec3d5f8e3a185b3ce3",
       "license": "Apache-2.0"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "scripts": {
     "test": "node tests/index.js"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dimdenGD/ultimate-ws.git"
@@ -38,8 +41,8 @@
   "homepage": "https://github.com/dimdenGD/ultimate-ws#readme",
   "dependencies": {
     "tseep": "^1.3.1",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.51.0",
-    "ws": "^8.18.0"
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.52.0",
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "exit-hook": "^2.2.1"


### PR DESCRIPTION
This PR updates uWebSockets.js to v20.52.0, plus includes the rest of the dependencies.
Due to the update, this package requires Node.js v20+ now.

All tests have been checked and pass.