### PR TITLE
Pass close code and reason to WebSocket close event

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -186,10 +186,10 @@ module.exports = class WebSocketServer extends EventEmitter {
                     this.emit("connection", ws.client, ws.req);
                 }
             },
-            close: (ws) => {
+            close: (ws, code, message) => {
                 ws.client.readyState = WS.CLOSED;
                 if(this.clients) this.clients.delete(ws.client);
-                ws.client.emit("close");
+                ws.client.emit("close", code, Buffer.from(message));
             },
             message: (ws, message, isBinary) => {
                 if(ws.client.isPaused) {


### PR DESCRIPTION
The uWebSockets.js `close` callback provides `(ws, code, message)` but the server-side close handler discards `code` and `message`, emitting the `close` event with no arguments.

This breaks libraries that listen for `ws`-compatible close events with `(code, reason)` parameters. For example, Hocuspocus v3 calls `reason.toString()` in its `handleWebsocketClose` handler, which throws `TypeError: Cannot read properties of undefined (reading 'toString')` when reason is not provided.

The fix passes `code` and `Buffer.from(message)` through to the emitted close event, matching the `ws` library's behavior.